### PR TITLE
drhuffman12/serializable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ require "ai4cr"
 
 So far, only Ai4cr::NeuralNetwork::Backpropagation and related tests have been ported.
 
+NOTE: `marshal_dump` and `marshal_load` are deprecated; use `to_json` and `from_json` instead, e.g.:
+
+```
+# Create and save a net
+net = Ai4cr::NeuralNetwork::Backpropagation.new(...)
+File.write("../ai4cr_ui/db/seeds/BackpropagationNet.new.json",net.to_json)
+
+# Train and save a net
+net.train(some_input, expected_output)
+File.write("../ai4cr_ui/db/seeds/BackpropagationNet.trained.json",net.to_json)
+
+# Verify serialization in a spec
+json = net.to_json
+net2 = Ai4cr::NeuralNetwork::Backpropagation.from_json(json)
+assert_approximate_equality_of_nested_list net.weights, net2.weights, 0.000000001
+```
+
+      
 If you'd like another class of Ai4r ported, feel free to submit a [new issue](https://github.com/drhuffman12/ai4cr/issues/new).
 
 ## Contributing

--- a/spec/ai4cr/neural_network/backpropagation_spec.cr
+++ b/spec/ai4cr/neural_network/backpropagation_spec.cr
@@ -156,41 +156,55 @@ describe Ai4cr::NeuralNetwork::Backpropagation do
     describe "when given a net with structure of [3, 2]" do
       structure = [3, 2]
       net = Ai4cr::NeuralNetwork::Backpropagation.new([3, 2]).init_network
-      # s = Marshal.dump(net)
-      # x = Marshal.load(s)
-      # s = net.to_json
-      # x = Ai4cr::NeuralNetwork::Backpropagation.from_json(s)
+
+      # TODO: Remove (marshal_dump and marshal_load are deprecated)
       s = net.marshal_dump
       structure = s[:structure]
       x = Ai4cr::NeuralNetwork::Backpropagation.new(structure).init_network
       x.marshal_load(s)
 
+      # NOTE: *_json replaces marshal_dump and marshal_load
+      json = net.to_json
+      net2 = Ai4cr::NeuralNetwork::Backpropagation.from_json(json)
+
       it "@structure of the dumped net matches @structure of the loaded net" do
-        assert_equality_of_nested_list net.structure, x.structure
+        assert_equality_of_nested_list net.structure, x.structure # TODO: Remove (marshal_dump and marshal_load are deprecated)
+        assert_equality_of_nested_list net.structure, net2.structure
       end
 
       it "@disable_bias on the dumped net matches @disable_bias of the loaded net" do
-        net.disable_bias.should eq(x.disable_bias)
+        net.disable_bias.should eq(x.disable_bias) # TODO: Remove (marshal_dump and marshal_load are deprecated)
+        net.disable_bias.should eq(net2.disable_bias)
       end
 
       it "@learning_rate of the dumped net approximately matches @learning_rate of the loaded net" do
-        assert_approximate_equality net.learning_rate, x.learning_rate
+        assert_approximate_equality net.learning_rate, x.learning_rate # TODO: Remove (marshal_dump and marshal_load are deprecated)
+        assert_approximate_equality net.learning_rate, net2.learning_rate
       end
 
       it "@momentum of the dumped net approximately matches @momentum of the loaded net" do
-        assert_approximate_equality net.momentum, x.momentum
+        assert_approximate_equality net.momentum, x.momentum # TODO: Remove (marshal_dump and marshal_load are deprecated)
+        assert_approximate_equality net.momentum, net2.momentum
       end
 
       it "@weights of the dumped net approximately matches @weights of the loaded net" do
-        assert_approximate_equality_of_nested_list net.weights, x.weights
+        assert_approximate_equality_of_nested_list net.weights, x.weights # TODO: Remove (marshal_dump and marshal_load are deprecated)
+        assert_approximate_equality_of_nested_list net.weights, net2.weights
       end
 
       it "@last_changes of the dumped net approximately matches @last_changes of the loaded net" do
-        assert_approximate_equality_of_nested_list net.last_changes, x.last_changes
+        assert_approximate_equality_of_nested_list net.last_changes, x.last_changes # TODO: Remove (marshal_dump and marshal_load are deprecated)
+        assert_approximate_equality_of_nested_list net.last_changes, net2.last_changes
       end
 
       it "@activation_nodes of the dumped net approximately matches @activation_nodes of the loaded net" do
-        assert_approximate_equality_of_nested_list net.activation_nodes, x.activation_nodes
+        assert_approximate_equality_of_nested_list net.activation_nodes, x.activation_nodes # TODO: Remove (marshal_dump and marshal_load are deprecated)
+        assert_approximate_equality_of_nested_list net.activation_nodes, net2.activation_nodes
+      end
+
+      it "@calculated_error_total of the dumped net approximately matches @calculated_error_total of the loaded net" do
+        assert_approximate_equality_of_nested_list net.calculated_error_total, x.calculated_error_total # TODO: Remove (marshal_dump and marshal_load are deprecated)
+        assert_approximate_equality_of_nested_list net.calculated_error_total, net2.calculated_error_total
       end
     end
   end

--- a/spec_examples/ai4cr/neural_network/backpropagation_spec.cr
+++ b/spec_examples/ai4cr/neural_network/backpropagation_spec.cr
@@ -29,9 +29,6 @@ describe Ai4cr::NeuralNetwork::Backpropagation do
 
       net = Ai4cr::NeuralNetwork::Backpropagation.new([256, 3])
 
-      # File.write("../ai4cr_ui/db/seeds/BackpropagationNet.json",JSON.parse(net.to_json))
-      File.write("../ai4cr_ui/db/seeds/BackpropagationNet.new.json",net.to_json)
-
       net.learning_rate = rand
       qty = 100000
 
@@ -145,8 +142,6 @@ describe Ai4cr::NeuralNetwork::Backpropagation do
           end
         end
       end
-
-      File.write("../ai4cr_ui/db/seeds/BackpropagationNet.trained.json",net.to_json)
     end
   end
 end

--- a/spec_examples/ai4cr/neural_network/backpropagation_spec.cr
+++ b/spec_examples/ai4cr/neural_network/backpropagation_spec.cr
@@ -2,6 +2,8 @@ require "./../../spec_helper"
 require "../../support/neural_network/data/training_patterns"
 require "../../support/neural_network/data/patterns_with_noise"
 require "../../support/neural_network/data/patterns_with_base_noise"
+# require "json/builder"
+require "json"
 
 describe Ai4cr::NeuralNetwork::Backpropagation do
   describe "#train" do
@@ -26,6 +28,10 @@ describe Ai4cr::NeuralNetwork::Backpropagation do
       cr_with_base_noise = CROSS_WITH_BASE_NOISE.flatten.map { |input| input.to_f / 5.0 }
 
       net = Ai4cr::NeuralNetwork::Backpropagation.new([256, 3])
+
+      # File.write("../ai4cr_ui/db/seeds/BackpropagationNet.json",JSON.parse(net.to_json))
+      File.write("../ai4cr_ui/db/seeds/BackpropagationNet.new.json",net.to_json)
+
       net.learning_rate = rand
       qty = 100000
 
@@ -43,6 +49,29 @@ describe Ai4cr::NeuralNetwork::Backpropagation do
             end
           end
           error_averages << (errors[:tr].to_f + errors[:sq].to_f + errors[:cr].to_f) / 3.0
+        end
+      
+        describe "JSON (de-)serialization works" do
+          it "@calculated_error_total of the dumped net approximately matches @calculated_error_total of the loaded net" do
+            json = net.to_json
+            net2 = Ai4cr::NeuralNetwork::Backpropagation.from_json(json)
+
+            assert_approximate_equality_of_nested_list net.calculated_error_total, net2.calculated_error_total, 0.000000001
+          end
+        
+          it "@activation_nodes of the dumped net approximately matches @activation_nodes of the loaded net" do
+            json = net.to_json
+            net2 = Ai4cr::NeuralNetwork::Backpropagation.from_json(json)
+
+            assert_approximate_equality_of_nested_list net.activation_nodes, net2.activation_nodes, 0.000000001
+          end
+        
+          it "@weights of the dumped net approximately matches @weights of the loaded net" do
+            json = net.to_json
+            net2 = Ai4cr::NeuralNetwork::Backpropagation.from_json(json)
+
+            assert_approximate_equality_of_nested_list net.weights, net2.weights, 0.000000001
+          end
         end
 
         describe "error_averages" do
@@ -116,6 +145,8 @@ describe Ai4cr::NeuralNetwork::Backpropagation do
           end
         end
       end
+
+      File.write("../ai4cr_ui/db/seeds/BackpropagationNet.trained.json",net.to_json)
     end
   end
 end


### PR DESCRIPTION
`marshal_dump` and `marshal_load` are deprecated; use `to_json` and `from_json` instead