### PR TITLE
Drhuffman12/add team utils part 3

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: ai4cr
-version: 0.1.20
+version: 0.1.21
 
 authors:
   - Daniel Huffman <drhuffman12@yahoo.com>

--- a/spec/ai4cr/neural_network/cmn/mini_net_manager_spec.cr
+++ b/spec/ai4cr/neural_network/cmn/mini_net_manager_spec.cr
@@ -21,13 +21,19 @@ Spectator.describe Ai4cr::NeuralNetwork::Cmn::MiniNetManager do
 
     let(config_adam) {
       config_default_randomized.merge(
-        name: "Adam", learning_rate: ancestor_adam_learning_rate_expected
+        name: "Adam",
+        learning_rate: ancestor_adam_learning_rate_expected,
+        momentum: Ai4cr::Data::Utils.rand_excluding,
+        deriv_scale: Ai4cr::Data::Utils.rand_excluding / 2.0
       )
     }
 
     let(config_eve) {
       config_default_randomized.merge(
-        name: "Eve", learning_rate: ancestor_eve_learning_rate_expected
+        name: "Eve",
+        learning_rate: ancestor_eve_learning_rate_expected,
+        momentum: Ai4cr::Data::Utils.rand_excluding,
+        deriv_scale: Ai4cr::Data::Utils.rand_excluding / 2.0
       )
     }
 
@@ -44,93 +50,93 @@ Spectator.describe Ai4cr::NeuralNetwork::Cmn::MiniNetManager do
       expect(ancestor_adam.learning_rate).not_to eq(ancestor_eve.learning_rate)
     end
 
-    # context "birth_id's are in the consistent order (when birthed in order" do
-    #   it "first Adam" do
-    #     expected_birth_counter = 0
+    context "birth_id's are in the consistent order (when birthed in order" do
+      it "first Adam" do
+        expected_birth_counter = 0
 
-    #     # Adam
-    #     expected_birth_counter += 1
-    #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+        # Adam
+        expected_birth_counter += 1
+        expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
 
-    #     puts_debug
-    #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-    #   end
+        puts_debug
+        puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+      end
 
-    #   it "first Adam then Eve" do
-    #     expected_birth_counter = 0
+      it "first Adam then Eve" do
+        expected_birth_counter = 0
 
-    #     # Adam
-    #     expected_birth_counter += 1
-    #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+        # Adam
+        expected_birth_counter += 1
+        expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
 
-    #     # Eve
-    #     expected_birth_counter += 1
-    #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+        # Eve
+        expected_birth_counter += 1
+        expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
 
-    #     puts_debug
-    #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-    #     puts_debug
-    #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-    #   end
+        puts_debug
+        puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+        puts_debug
+        puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+      end
 
-    #   it "first Adam then Eve followed by Cain" do
-    #     expected_birth_counter = 0
+      it "first Adam then Eve followed by Cain" do
+        expected_birth_counter = 0
 
-    #     # Adam
-    #     expected_birth_counter += 1
-    #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+        # Adam
+        expected_birth_counter += 1
+        expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
 
-    #     # Eve
-    #     expected_birth_counter += 1
-    #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+        # Eve
+        expected_birth_counter += 1
+        expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
 
-    #     # Cain
-    #     expected_birth_counter += 1
-    #     child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
-    #     child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-    #     expect(child_1.birth_id).to eq(expected_birth_counter)
+        # Cain
+        expected_birth_counter += 1
+        child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
+        child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+        expect(child_1.birth_id).to eq(expected_birth_counter)
 
-    #     puts_debug
-    #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-    #     puts_debug
-    #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-    #     puts_debug
-    #     puts_debug "child_1: #{child_1.to_json}"
-    #   end
+        puts_debug
+        puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+        puts_debug
+        puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+        puts_debug
+        puts_debug "child_1: #{child_1.to_json}"
+      end
 
-    #   it "first Adam then Eve followed by Cain and then Abel" do
-    #     expected_birth_counter = 0
+      it "first Adam then Eve followed by Cain and then Abel" do
+        expected_birth_counter = 0
 
-    #     # Adam
-    #     expected_birth_counter += 1
-    #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+        # Adam
+        expected_birth_counter += 1
+        expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
 
-    #     # Eve
-    #     expected_birth_counter += 1
-    #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+        # Eve
+        expected_birth_counter += 1
+        expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
 
-    #     # Cain
-    #     expected_birth_counter += 1
-    #     child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
-    #     child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-    #     expect(child_1.birth_id).to eq(expected_birth_counter)
+        # Cain
+        expected_birth_counter += 1
+        child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
+        child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+        expect(child_1.birth_id).to eq(expected_birth_counter)
 
-    #     # Abel
-    #     expected_birth_counter += 1
-    #     child_2 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_2)
-    #     child_2.name = "Abel, child of #{child_2.name} and #{ancestor_eve.name}"
-    #     expect(child_2.birth_id).to eq(expected_birth_counter)
+        # Abel
+        expected_birth_counter += 1
+        child_2 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_2)
+        child_2.name = "Abel, child of #{child_2.name} and #{ancestor_eve.name}"
+        expect(child_2.birth_id).to eq(expected_birth_counter)
 
-    #     puts_debug
-    #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-    #     puts_debug
-    #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-    #     puts_debug
-    #     puts_debug "child_1: #{child_1.to_json}"
-    #     puts_debug
-    #     puts_debug "child_2: #{child_2.to_json}"
-    #   end
-    # end
+        puts_debug
+        puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+        puts_debug
+        puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+        puts_debug
+        puts_debug "child_1: #{child_1.to_json}"
+        puts_debug
+        puts_debug "child_2: #{child_2.to_json}"
+      end
+    end
 
     describe "#mix_parts" do
       context "first Adam then Eve followed by Cain" do
@@ -214,91 +220,3 @@ Spectator.describe Ai4cr::NeuralNetwork::Cmn::MiniNetManager do
     end
   end
 end
-
-# let(weights_expected_1) {
-#   ancestor_adam.weights.map_with_index do |sa, i|
-#     parent_a_part = sa
-#     parent_b_part = ancestor_eve.weights[i]
-
-#     vector_a_to_b = parent_b_part - parent_a_part
-#     parent_a_part + (delta_child_1 * vector_a_to_b)
-#   end
-# }
-# let(weights_expected_2) {
-#   ancestor_adam.weights.map_with_index do |sa, i|
-#     parent_a_part = sa
-#     parent_b_part = ancestor_eve.weights[i]
-
-#     vector_a_to_b = parent_b_part - parent_a_part
-#     parent_a_part + (delta_child_2 * vector_a_to_b)
-#   end
-# }
-
-# let(momentum_expected_1) {
-#   ancestor_adam.momentum.map_with_index do |sa, i|
-#     parent_a_part = sa
-#     parent_b_part = ancestor_eve.momentum[i]
-
-#     vector_a_to_b = parent_b_part - parent_a_part
-#     parent_a_part + (delta_child_1 * vector_a_to_b)
-#   end
-# }
-# let(momentum_expected_2) {
-#   ancestor_adam.momentum.map_with_index do |sa, i|
-#     parent_a_part = sa
-#     parent_b_part = ancestor_eve.momentum[i]
-
-#     vector_a_to_b = parent_b_part - parent_a_part
-#     parent_a_part + (delta_child_2 * vector_a_to_b)
-#   end
-# }
-
-# let(config_cain) {
-#   config_default_randomized.merge(
-#     name: "Cain", learning_rate: ancestor_adam_learning_rate_expected
-#   )
-# }
-
-# let(config_abel) {
-#   config_default_randomized.merge(
-#     name: "Abel", learning_rate: ancestor_adam_learning_rate_expected
-#   )
-# }
-
-# expect(ancestor_adam.learning_rate).to eq(ancestor_adam_learning_rate_expected)
-
-# expected_birth_counter += 1
-# expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
-# expect(ancestor_eve.learning_rate).to eq(ancestor_eve_learning_rate_expected)
-
-# # cain
-# child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
-# child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-
-# puts_debug "child_1: #{child_1.to_json}"
-# expected_birth_counter += 1
-# expect(child_1.birth_id).to eq(expected_birth_counter)
-# expect(child_1.learning_rate).to eq(delta_child_1)
-
-# # expect(child_1.weights).to eq(weights_expected_1)
-# # expect(child_1.momentum).to eq(momentum_expected_1)
-
-# # abel
-# child_2 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_2)
-# child_2.name = "Abel, child of #{child_2.name} and #{ancestor_eve.name}"
-
-# puts_debug "child_2: #{child_2.to_json}"
-# expected_birth_counter += 1
-# expect(child_2.birth_id).to eq(expected_birth_counter)
-# expect(child_2.learning_rate).to eq(delta_child_2)
-
-# # expect(child_2.weights).to eq(weights_expected_2)
-# # expect(child_2.momentum).to eq(momentum_expected_2)
-
-# puts_debug
-# puts_debug "Now, in order or youngest to oldest:"
-# [ancestor_adam, ancestor_eve, child_1, child_2].sort_by do |person|
-#   (- person.birth_id)
-# end.each do |person|
-#   puts_debug "person: #{person.to_json}"
-# end

--- a/spec/ai4cr/neural_network/rnn/rnn_simple_manager_spec.cr
+++ b/spec/ai4cr/neural_network/rnn/rnn_simple_manager_spec.cr
@@ -9,209 +9,209 @@ Spectator.describe Ai4cr::NeuralNetwork::Rnn::RnnSimpleManager do
   let(my_breed_manager) { Ai4cr::NeuralNetwork::Rnn::RnnSimpleManager.new }
 
   describe "For Adam and Eve examples" do
-  #   let(delta_child_1) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
-  #   let(delta_child_2) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
+    #   let(delta_child_1) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
+    #   let(delta_child_2) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
 
-  #   let(ancestor_adam_learning_rate_expected) { 0.1 }
-  #   let(ancestor_eve_learning_rate_expected) { 0.9 }
+    #   let(ancestor_adam_learning_rate_expected) { 0.1 }
+    #   let(ancestor_eve_learning_rate_expected) { 0.9 }
 
-  #   let(config_default_randomized) {
-  #     Ai4cr::NeuralNetwork::Cmn::MiniNet.new.config
-  #   }
+    #   let(config_default_randomized) {
+    #     Ai4cr::NeuralNetwork::Cmn::MiniNet.new.config
+    #   }
 
-  #   let(config_adam) {
-  #     config_default_randomized.merge(
-  #       name: "Adam", learning_rate: ancestor_adam_learning_rate_expected
-  #     )
-  #   }
+    #   let(config_adam) {
+    #     config_default_randomized.merge(
+    #       name: "Adam", learning_rate: ancestor_adam_learning_rate_expected
+    #     )
+    #   }
 
-  #   let(config_eve) {
-  #     config_default_randomized.merge(
-  #       name: "Eve", learning_rate: ancestor_eve_learning_rate_expected
-  #     )
-  #   }
+    #   let(config_eve) {
+    #     config_default_randomized.merge(
+    #       name: "Eve", learning_rate: ancestor_eve_learning_rate_expected
+    #     )
+    #   }
 
-  #   let(ancestor_adam) { my_breed_manager.create(**config_adam) }
-  #   let(ancestor_eve) { my_breed_manager.create(**config_eve) }
+    #   let(ancestor_adam) { my_breed_manager.create(**config_adam) }
+    #   let(ancestor_eve) { my_breed_manager.create(**config_eve) }
 
-  #   before_each do
-  #     my_breed_manager.counter_reset
-  #   end
+    #   before_each do
+    #     my_breed_manager.counter_reset
+    #   end
 
-  #   it "learning rates of Adam and Eve are different" do
-  #     expect(ancestor_adam.learning_rate).to eq(ancestor_adam_learning_rate_expected)
-  #     expect(ancestor_eve.learning_rate).to eq(ancestor_eve_learning_rate_expected)
-  #     expect(ancestor_adam.learning_rate).not_to eq(ancestor_eve.learning_rate)
-  #   end
+    #   it "learning rates of Adam and Eve are different" do
+    #     expect(ancestor_adam.learning_rate).to eq(ancestor_adam_learning_rate_expected)
+    #     expect(ancestor_eve.learning_rate).to eq(ancestor_eve_learning_rate_expected)
+    #     expect(ancestor_adam.learning_rate).not_to eq(ancestor_eve.learning_rate)
+    #   end
 
-  #   # context "birth_id's are in the consistent order (when birthed in order" do
-  #   #   it "first Adam" do
-  #   #     expected_birth_counter = 0
+    #   # context "birth_id's are in the consistent order (when birthed in order" do
+    #   #   it "first Adam" do
+    #   #     expected_birth_counter = 0
 
-  #   #     # Adam
-  #   #     expected_birth_counter += 1
-  #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+    #   #     # Adam
+    #   #     expected_birth_counter += 1
+    #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
 
-  #   #     puts_debug
-  #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-  #   #   end
+    #   #     puts_debug
+    #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+    #   #   end
 
-  #   #   it "first Adam then Eve" do
-  #   #     expected_birth_counter = 0
+    #   #   it "first Adam then Eve" do
+    #   #     expected_birth_counter = 0
 
-  #   #     # Adam
-  #   #     expected_birth_counter += 1
-  #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+    #   #     # Adam
+    #   #     expected_birth_counter += 1
+    #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
 
-  #   #     # Eve
-  #   #     expected_birth_counter += 1
-  #   #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+    #   #     # Eve
+    #   #     expected_birth_counter += 1
+    #   #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
 
-  #   #     puts_debug
-  #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-  #   #     puts_debug
-  #   #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-  #   #   end
+    #   #     puts_debug
+    #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+    #   #     puts_debug
+    #   #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+    #   #   end
 
-  #   #   it "first Adam then Eve followed by Cain" do
-  #   #     expected_birth_counter = 0
+    #   #   it "first Adam then Eve followed by Cain" do
+    #   #     expected_birth_counter = 0
 
-  #   #     # Adam
-  #   #     expected_birth_counter += 1
-  #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+    #   #     # Adam
+    #   #     expected_birth_counter += 1
+    #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
 
-  #   #     # Eve
-  #   #     expected_birth_counter += 1
-  #   #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+    #   #     # Eve
+    #   #     expected_birth_counter += 1
+    #   #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
 
-  #   #     # Cain
-  #   #     expected_birth_counter += 1
-  #   #     child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
-  #   #     child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-  #   #     expect(child_1.birth_id).to eq(expected_birth_counter)
+    #   #     # Cain
+    #   #     expected_birth_counter += 1
+    #   #     child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
+    #   #     child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+    #   #     expect(child_1.birth_id).to eq(expected_birth_counter)
 
-  #   #     puts_debug
-  #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-  #   #     puts_debug
-  #   #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-  #   #     puts_debug
-  #   #     puts_debug "child_1: #{child_1.to_json}"
-  #   #   end
+    #   #     puts_debug
+    #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+    #   #     puts_debug
+    #   #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+    #   #     puts_debug
+    #   #     puts_debug "child_1: #{child_1.to_json}"
+    #   #   end
 
-  #   #   it "first Adam then Eve followed by Cain and then Abel" do
-  #   #     expected_birth_counter = 0
+    #   #   it "first Adam then Eve followed by Cain and then Abel" do
+    #   #     expected_birth_counter = 0
 
-  #   #     # Adam
-  #   #     expected_birth_counter += 1
-  #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+    #   #     # Adam
+    #   #     expected_birth_counter += 1
+    #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
 
-  #   #     # Eve
-  #   #     expected_birth_counter += 1
-  #   #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+    #   #     # Eve
+    #   #     expected_birth_counter += 1
+    #   #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
 
-  #   #     # Cain
-  #   #     expected_birth_counter += 1
-  #   #     child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
-  #   #     child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-  #   #     expect(child_1.birth_id).to eq(expected_birth_counter)
+    #   #     # Cain
+    #   #     expected_birth_counter += 1
+    #   #     child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
+    #   #     child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+    #   #     expect(child_1.birth_id).to eq(expected_birth_counter)
 
-  #   #     # Abel
-  #   #     expected_birth_counter += 1
-  #   #     child_2 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_2)
-  #   #     child_2.name = "Abel, child of #{child_2.name} and #{ancestor_eve.name}"
-  #   #     expect(child_2.birth_id).to eq(expected_birth_counter)
+    #   #     # Abel
+    #   #     expected_birth_counter += 1
+    #   #     child_2 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_2)
+    #   #     child_2.name = "Abel, child of #{child_2.name} and #{ancestor_eve.name}"
+    #   #     expect(child_2.birth_id).to eq(expected_birth_counter)
 
-  #   #     puts_debug
-  #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-  #   #     puts_debug
-  #   #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-  #   #     puts_debug
-  #   #     puts_debug "child_1: #{child_1.to_json}"
-  #   #     puts_debug
-  #   #     puts_debug "child_2: #{child_2.to_json}"
-  #   #   end
-  #   # end
+    #   #     puts_debug
+    #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+    #   #     puts_debug
+    #   #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+    #   #     puts_debug
+    #   #     puts_debug "child_1: #{child_1.to_json}"
+    #   #     puts_debug
+    #   #     puts_debug "child_2: #{child_2.to_json}"
+    #   #   end
+    #   # end
 
-  #   describe "#mix_parts" do
-  #     context "first Adam then Eve followed by Cain" do
-  #       let(child_1) { my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1) }
+    #   describe "#mix_parts" do
+    #     context "first Adam then Eve followed by Cain" do
+    #       let(child_1) { my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1) }
 
-  #       let(learning_rate_expected_1) {
-  #         parent_a_part = ancestor_adam.learning_rate
-  #         parent_b_part = ancestor_eve.learning_rate
+    #       let(learning_rate_expected_1) {
+    #         parent_a_part = ancestor_adam.learning_rate
+    #         parent_b_part = ancestor_eve.learning_rate
 
-  #         vector_a_to_b = parent_b_part - parent_a_part
-  #         parent_a_part + (delta_child_1 * vector_a_to_b)
-  #       }
+    #         vector_a_to_b = parent_b_part - parent_a_part
+    #         parent_a_part + (delta_child_1 * vector_a_to_b)
+    #       }
 
-  #       let(momentum_expected_1) {
-  #         parent_a_part = ancestor_adam.momentum
-  #         parent_b_part = ancestor_eve.momentum
+    #       let(momentum_expected_1) {
+    #         parent_a_part = ancestor_adam.momentum
+    #         parent_b_part = ancestor_eve.momentum
 
-  #         vector_a_to_b = parent_b_part - parent_a_part
-  #         parent_a_part + (delta_child_1 * vector_a_to_b)
-  #       }
+    #         vector_a_to_b = parent_b_part - parent_a_part
+    #         parent_a_part + (delta_child_1 * vector_a_to_b)
+    #       }
 
-  #       before_each do
-  #         # Force variable to be initialized in specific order
+    #       before_each do
+    #         # Force variable to be initialized in specific order
 
-  #         # Adam
-  #         ancestor_adam.name = ancestor_adam.name + ""
+    #         # Adam
+    #         ancestor_adam.name = ancestor_adam.name + ""
 
-  #         # Eve
-  #         ancestor_eve.name = ancestor_eve.name + ""
+    #         # Eve
+    #         ancestor_eve.name = ancestor_eve.name + ""
 
-  #         # Cain
-  #         child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-  #       end
+    #         # Cain
+    #         child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+    #       end
 
-  #       it "debug" do
-  #         puts_debug
-  #         puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-  #         puts_debug
-  #         puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-  #         puts_debug
-  #         puts_debug "child_1: #{child_1.to_json}"
-  #         puts_debug
+    #       it "debug" do
+    #         puts_debug
+    #         puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+    #         puts_debug
+    #         puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+    #         puts_debug
+    #         puts_debug "child_1: #{child_1.to_json}"
+    #         puts_debug
 
-  #         # puts_debug
-  #         # puts_debug "ancestor_adam: #{ancestor_adam.to_pretty_json}"
-  #         # puts_debug
-  #         # puts_debug "ancestor_eve: #{ancestor_eve.to_pretty_json}"
-  #         # puts_debug
-  #         # puts_debug "child_1: #{child_1.to_pretty_json}"
-  #         # puts_debug
-  #       end
+    #         # puts_debug
+    #         # puts_debug "ancestor_adam: #{ancestor_adam.to_pretty_json}"
+    #         # puts_debug
+    #         # puts_debug "ancestor_eve: #{ancestor_eve.to_pretty_json}"
+    #         # puts_debug
+    #         # puts_debug "child_1: #{child_1.to_pretty_json}"
+    #         # puts_debug
+    #       end
 
-  #       context "first child" do
-  #         context "gets expected value(s) for" do
-  #           it "learning_rate" do
-  #             expect(child_1.learning_rate).to eq(learning_rate_expected_1)
-  #           end
+    #       context "first child" do
+    #         context "gets expected value(s) for" do
+    #           it "learning_rate" do
+    #             expect(child_1.learning_rate).to eq(learning_rate_expected_1)
+    #           end
 
-  #           it "momentum" do
-  #             expect(child_1.momentum).to eq(momentum_expected_1)
-  #           end
+    #           it "momentum" do
+    #             expect(child_1.momentum).to eq(momentum_expected_1)
+    #           end
 
-  #           # ... do likewise for other applicable variables
-  #         end
+    #           # ... do likewise for other applicable variables
+    #         end
 
-  #         context "does not get exact copy of either parent for values of" do
-  #           it "learning_rate" do
-  #             expect(child_1.learning_rate).not_to eq(ancestor_adam)
-  #             expect(child_1.learning_rate).not_to eq(ancestor_eve)
-  #           end
+    #         context "does not get exact copy of either parent for values of" do
+    #           it "learning_rate" do
+    #             expect(child_1.learning_rate).not_to eq(ancestor_adam)
+    #             expect(child_1.learning_rate).not_to eq(ancestor_eve)
+    #           end
 
-  #           it "momentum" do
-  #             expect(child_1.momentum).not_to eq(ancestor_adam)
-  #             expect(child_1.momentum).not_to eq(ancestor_eve)
-  #           end
+    #           it "momentum" do
+    #             expect(child_1.momentum).not_to eq(ancestor_adam)
+    #             expect(child_1.momentum).not_to eq(ancestor_eve)
+    #           end
 
-  #           # ... do likewise for other applicable variables
-  #         end
-  #       end
-  #     end
-  #   end
+    #           # ... do likewise for other applicable variables
+    #         end
+    #       end
+    #     end
+    #   end
   end
 end
 

--- a/spec/ai4cr/neural_network/rnn/rnn_simple_manager_spec.cr
+++ b/spec/ai4cr/neural_network/rnn/rnn_simple_manager_spec.cr
@@ -1,0 +1,304 @@
+require "./../../../spec_helper"
+require "./../../../spectator_helper"
+
+def puts_debug(message = "")
+  puts message if ENV.has_key?("DEBUG") && ENV["DEBUG"] == "1"
+end
+
+Spectator.describe Ai4cr::NeuralNetwork::Rnn::RnnSimpleManager do
+  let(my_breed_manager) { Ai4cr::NeuralNetwork::Rnn::RnnSimpleManager.new }
+
+  # describe "For Adam and Eve examples" do
+  #   let(delta_child_1) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
+  #   let(delta_child_2) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
+
+  #   let(ancestor_adam_learning_rate_expected) { 0.1 }
+  #   let(ancestor_eve_learning_rate_expected) { 0.9 }
+
+  #   let(config_default_randomized) {
+  #     Ai4cr::NeuralNetwork::Cmn::MiniNet.new.config
+  #   }
+
+  #   let(config_adam) {
+  #     config_default_randomized.merge(
+  #       name: "Adam", learning_rate: ancestor_adam_learning_rate_expected
+  #     )
+  #   }
+
+  #   let(config_eve) {
+  #     config_default_randomized.merge(
+  #       name: "Eve", learning_rate: ancestor_eve_learning_rate_expected
+  #     )
+  #   }
+
+  #   let(ancestor_adam) { my_breed_manager.create(**config_adam) }
+  #   let(ancestor_eve) { my_breed_manager.create(**config_eve) }
+
+  #   before_each do
+  #     my_breed_manager.counter_reset
+  #   end
+
+  #   it "learning rates of Adam and Eve are different" do
+  #     expect(ancestor_adam.learning_rate).to eq(ancestor_adam_learning_rate_expected)
+  #     expect(ancestor_eve.learning_rate).to eq(ancestor_eve_learning_rate_expected)
+  #     expect(ancestor_adam.learning_rate).not_to eq(ancestor_eve.learning_rate)
+  #   end
+
+  #   # context "birth_id's are in the consistent order (when birthed in order" do
+  #   #   it "first Adam" do
+  #   #     expected_birth_counter = 0
+
+  #   #     # Adam
+  #   #     expected_birth_counter += 1
+  #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+
+  #   #     puts_debug
+  #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+  #   #   end
+
+  #   #   it "first Adam then Eve" do
+  #   #     expected_birth_counter = 0
+
+  #   #     # Adam
+  #   #     expected_birth_counter += 1
+  #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+
+  #   #     # Eve
+  #   #     expected_birth_counter += 1
+  #   #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+
+  #   #     puts_debug
+  #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+  #   #     puts_debug
+  #   #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+  #   #   end
+
+  #   #   it "first Adam then Eve followed by Cain" do
+  #   #     expected_birth_counter = 0
+
+  #   #     # Adam
+  #   #     expected_birth_counter += 1
+  #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+
+  #   #     # Eve
+  #   #     expected_birth_counter += 1
+  #   #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+
+  #   #     # Cain
+  #   #     expected_birth_counter += 1
+  #   #     child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
+  #   #     child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+  #   #     expect(child_1.birth_id).to eq(expected_birth_counter)
+
+  #   #     puts_debug
+  #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+  #   #     puts_debug
+  #   #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+  #   #     puts_debug
+  #   #     puts_debug "child_1: #{child_1.to_json}"
+  #   #   end
+
+  #   #   it "first Adam then Eve followed by Cain and then Abel" do
+  #   #     expected_birth_counter = 0
+
+  #   #     # Adam
+  #   #     expected_birth_counter += 1
+  #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+
+  #   #     # Eve
+  #   #     expected_birth_counter += 1
+  #   #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+
+  #   #     # Cain
+  #   #     expected_birth_counter += 1
+  #   #     child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
+  #   #     child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+  #   #     expect(child_1.birth_id).to eq(expected_birth_counter)
+
+  #   #     # Abel
+  #   #     expected_birth_counter += 1
+  #   #     child_2 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_2)
+  #   #     child_2.name = "Abel, child of #{child_2.name} and #{ancestor_eve.name}"
+  #   #     expect(child_2.birth_id).to eq(expected_birth_counter)
+
+  #   #     puts_debug
+  #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+  #   #     puts_debug
+  #   #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+  #   #     puts_debug
+  #   #     puts_debug "child_1: #{child_1.to_json}"
+  #   #     puts_debug
+  #   #     puts_debug "child_2: #{child_2.to_json}"
+  #   #   end
+  #   # end
+
+  #   describe "#mix_parts" do
+  #     context "first Adam then Eve followed by Cain" do
+  #       let(child_1) { my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1) }
+
+  #       let(learning_rate_expected_1) {
+  #         parent_a_part = ancestor_adam.learning_rate
+  #         parent_b_part = ancestor_eve.learning_rate
+
+  #         vector_a_to_b = parent_b_part - parent_a_part
+  #         parent_a_part + (delta_child_1 * vector_a_to_b)
+  #       }
+
+  #       let(momentum_expected_1) {
+  #         parent_a_part = ancestor_adam.momentum
+  #         parent_b_part = ancestor_eve.momentum
+
+  #         vector_a_to_b = parent_b_part - parent_a_part
+  #         parent_a_part + (delta_child_1 * vector_a_to_b)
+  #       }
+
+  #       before_each do
+  #         # Force variable to be initialized in specific order
+
+  #         # Adam
+  #         ancestor_adam.name = ancestor_adam.name + ""
+
+  #         # Eve
+  #         ancestor_eve.name = ancestor_eve.name + ""
+
+  #         # Cain
+  #         child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+  #       end
+
+  #       it "debug" do
+  #         puts_debug
+  #         puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+  #         puts_debug
+  #         puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+  #         puts_debug
+  #         puts_debug "child_1: #{child_1.to_json}"
+  #         puts_debug
+
+  #         # puts_debug
+  #         # puts_debug "ancestor_adam: #{ancestor_adam.to_pretty_json}"
+  #         # puts_debug
+  #         # puts_debug "ancestor_eve: #{ancestor_eve.to_pretty_json}"
+  #         # puts_debug
+  #         # puts_debug "child_1: #{child_1.to_pretty_json}"
+  #         # puts_debug
+  #       end
+
+  #       context "first child" do
+  #         context "gets expected value(s) for" do
+  #           it "learning_rate" do
+  #             expect(child_1.learning_rate).to eq(learning_rate_expected_1)
+  #           end
+
+  #           it "momentum" do
+  #             expect(child_1.momentum).to eq(momentum_expected_1)
+  #           end
+
+  #           # ... do likewise for other applicable variables
+  #         end
+
+  #         context "does not get exact copy of either parent for values of" do
+  #           it "learning_rate" do
+  #             expect(child_1.learning_rate).not_to eq(ancestor_adam)
+  #             expect(child_1.learning_rate).not_to eq(ancestor_eve)
+  #           end
+
+  #           it "momentum" do
+  #             expect(child_1.momentum).not_to eq(ancestor_adam)
+  #             expect(child_1.momentum).not_to eq(ancestor_eve)
+  #           end
+
+  #           # ... do likewise for other applicable variables
+  #         end
+  #       end
+  #     end
+  #   end
+  # end
+end
+
+# let(weights_expected_1) {
+#   ancestor_adam.weights.map_with_index do |sa, i|
+#     parent_a_part = sa
+#     parent_b_part = ancestor_eve.weights[i]
+
+#     vector_a_to_b = parent_b_part - parent_a_part
+#     parent_a_part + (delta_child_1 * vector_a_to_b)
+#   end
+# }
+# let(weights_expected_2) {
+#   ancestor_adam.weights.map_with_index do |sa, i|
+#     parent_a_part = sa
+#     parent_b_part = ancestor_eve.weights[i]
+
+#     vector_a_to_b = parent_b_part - parent_a_part
+#     parent_a_part + (delta_child_2 * vector_a_to_b)
+#   end
+# }
+
+# let(momentum_expected_1) {
+#   ancestor_adam.momentum.map_with_index do |sa, i|
+#     parent_a_part = sa
+#     parent_b_part = ancestor_eve.momentum[i]
+
+#     vector_a_to_b = parent_b_part - parent_a_part
+#     parent_a_part + (delta_child_1 * vector_a_to_b)
+#   end
+# }
+# let(momentum_expected_2) {
+#   ancestor_adam.momentum.map_with_index do |sa, i|
+#     parent_a_part = sa
+#     parent_b_part = ancestor_eve.momentum[i]
+
+#     vector_a_to_b = parent_b_part - parent_a_part
+#     parent_a_part + (delta_child_2 * vector_a_to_b)
+#   end
+# }
+
+# let(config_cain) {
+#   config_default_randomized.merge(
+#     name: "Cain", learning_rate: ancestor_adam_learning_rate_expected
+#   )
+# }
+
+# let(config_abel) {
+#   config_default_randomized.merge(
+#     name: "Abel", learning_rate: ancestor_adam_learning_rate_expected
+#   )
+# }
+
+# expect(ancestor_adam.learning_rate).to eq(ancestor_adam_learning_rate_expected)
+
+# expected_birth_counter += 1
+# expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+# expect(ancestor_eve.learning_rate).to eq(ancestor_eve_learning_rate_expected)
+
+# # cain
+# child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
+# child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+
+# puts_debug "child_1: #{child_1.to_json}"
+# expected_birth_counter += 1
+# expect(child_1.birth_id).to eq(expected_birth_counter)
+# expect(child_1.learning_rate).to eq(delta_child_1)
+
+# # expect(child_1.weights).to eq(weights_expected_1)
+# # expect(child_1.momentum).to eq(momentum_expected_1)
+
+# # abel
+# child_2 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_2)
+# child_2.name = "Abel, child of #{child_2.name} and #{ancestor_eve.name}"
+
+# puts_debug "child_2: #{child_2.to_json}"
+# expected_birth_counter += 1
+# expect(child_2.birth_id).to eq(expected_birth_counter)
+# expect(child_2.learning_rate).to eq(delta_child_2)
+
+# # expect(child_2.weights).to eq(weights_expected_2)
+# # expect(child_2.momentum).to eq(momentum_expected_2)
+
+# puts_debug
+# puts_debug "Now, in order or youngest to oldest:"
+# [ancestor_adam, ancestor_eve, child_1, child_2].sort_by do |person|
+#   (- person.birth_id)
+# end.each do |person|
+#   puts_debug "person: #{person.to_json}"
+# end

--- a/spec/ai4cr/neural_network/rnn/rnn_simple_manager_spec.cr
+++ b/spec/ai4cr/neural_network/rnn/rnn_simple_manager_spec.cr
@@ -9,296 +9,270 @@ Spectator.describe Ai4cr::NeuralNetwork::Rnn::RnnSimpleManager do
   let(my_breed_manager) { Ai4cr::NeuralNetwork::Rnn::RnnSimpleManager.new }
 
   describe "For Adam and Eve examples" do
-    #   let(delta_child_1) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
-    #   let(delta_child_2) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
+      let(delta_child_1) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
+      let(delta_child_2) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
 
-    #   let(ancestor_adam_learning_rate_expected) { 0.1 }
-    #   let(ancestor_eve_learning_rate_expected) { 0.9 }
+      let(ancestor_adam_learning_rate_expected) { 0.1 }
+      let(ancestor_eve_learning_rate_expected) { 0.9 }
 
-    #   let(config_default_randomized) {
-    #     Ai4cr::NeuralNetwork::Cmn::MiniNet.new.config
-    #   }
+      let(config_default_randomized) {
+        Ai4cr::NeuralNetwork::Rnn::RnnSimple.new.config
+      }
 
-    #   let(config_adam) {
-    #     config_default_randomized.merge(
-    #       name: "Adam", learning_rate: ancestor_adam_learning_rate_expected
-    #     )
-    #   }
+      let(config_adam) {
+        config_default_randomized.merge(
+          name: "Adam", learning_rate: ancestor_adam_learning_rate_expected,
+          momentum: Ai4cr::Data::Utils.rand_excluding,
+          deriv_scale: Ai4cr::Data::Utils.rand_excluding / 2.0
+        )
+      }
 
-    #   let(config_eve) {
-    #     config_default_randomized.merge(
-    #       name: "Eve", learning_rate: ancestor_eve_learning_rate_expected
-    #     )
-    #   }
+      let(config_eve) {
+        config_default_randomized.merge(
+          name: "Eve", learning_rate: ancestor_eve_learning_rate_expected,
+          momentum: Ai4cr::Data::Utils.rand_excluding,
+          deriv_scale: Ai4cr::Data::Utils.rand_excluding / 2.0
+        )
+      }
 
-    #   let(ancestor_adam) { my_breed_manager.create(**config_adam) }
-    #   let(ancestor_eve) { my_breed_manager.create(**config_eve) }
+      let(ancestor_adam) { my_breed_manager.create(**config_adam) }
+      let(ancestor_eve) { my_breed_manager.create(**config_eve) }
 
-    #   before_each do
-    #     my_breed_manager.counter_reset
-    #   end
+      before_each do
+        my_breed_manager.counter_reset
+      end
+      
+      it "learning rates of Adam and Eve are different" do
+        expect(ancestor_adam.learning_rate).to eq(ancestor_adam_learning_rate_expected)
+        expect(ancestor_eve.learning_rate).to eq(ancestor_eve_learning_rate_expected)
+        expect(ancestor_adam.learning_rate).not_to eq(ancestor_eve.learning_rate)
+      end
 
-    #   it "learning rates of Adam and Eve are different" do
-    #     expect(ancestor_adam.learning_rate).to eq(ancestor_adam_learning_rate_expected)
-    #     expect(ancestor_eve.learning_rate).to eq(ancestor_eve_learning_rate_expected)
-    #     expect(ancestor_adam.learning_rate).not_to eq(ancestor_eve.learning_rate)
-    #   end
+      context "birth_id's are in the consistent order (when birthed in order" do
+        it "first Adam" do
+          expected_birth_counter = 0
 
-    #   # context "birth_id's are in the consistent order (when birthed in order" do
-    #   #   it "first Adam" do
-    #   #     expected_birth_counter = 0
+          # Adam
+          expected_birth_counter += 1
+          expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
 
-    #   #     # Adam
-    #   #     expected_birth_counter += 1
-    #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+          puts_debug
+          puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+        end
 
-    #   #     puts_debug
-    #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-    #   #   end
+        it "first Adam then Eve" do
+          expected_birth_counter = 0
 
-    #   #   it "first Adam then Eve" do
-    #   #     expected_birth_counter = 0
+          # Adam
+          expected_birth_counter += 1
+          expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
 
-    #   #     # Adam
-    #   #     expected_birth_counter += 1
-    #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+          # Eve
+          expected_birth_counter += 1
+          expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
 
-    #   #     # Eve
-    #   #     expected_birth_counter += 1
-    #   #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+          puts_debug
+          puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+          puts_debug
+          puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+        end
 
-    #   #     puts_debug
-    #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-    #   #     puts_debug
-    #   #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-    #   #   end
+        it "first Adam then Eve followed by Cain" do
+          expected_birth_counter = 0
 
-    #   #   it "first Adam then Eve followed by Cain" do
-    #   #     expected_birth_counter = 0
+          # Adam
+          expected_birth_counter += 1
+          expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
 
-    #   #     # Adam
-    #   #     expected_birth_counter += 1
-    #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+          # Eve
+          expected_birth_counter += 1
+          expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
 
-    #   #     # Eve
-    #   #     expected_birth_counter += 1
-    #   #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+          # Cain
+          expected_birth_counter += 1
+          child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
+          child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+          expect(child_1.birth_id).to eq(expected_birth_counter)
 
-    #   #     # Cain
-    #   #     expected_birth_counter += 1
-    #   #     child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
-    #   #     child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-    #   #     expect(child_1.birth_id).to eq(expected_birth_counter)
+          puts_debug
+          puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+          puts_debug
+          puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+          puts_debug
+          puts_debug "child_1: #{child_1.to_json}"
+        end
 
-    #   #     puts_debug
-    #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-    #   #     puts_debug
-    #   #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-    #   #     puts_debug
-    #   #     puts_debug "child_1: #{child_1.to_json}"
-    #   #   end
+        it "first Adam then Eve followed by Cain and then Abel" do
+          expected_birth_counter = 0
 
-    #   #   it "first Adam then Eve followed by Cain and then Abel" do
-    #   #     expected_birth_counter = 0
+          # Adam
+          expected_birth_counter += 1
+          expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
 
-    #   #     # Adam
-    #   #     expected_birth_counter += 1
-    #   #     expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+          # Eve
+          expected_birth_counter += 1
+          expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
 
-    #   #     # Eve
-    #   #     expected_birth_counter += 1
-    #   #     expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+          # Cain
+          expected_birth_counter += 1
+          child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
+          child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+          expect(child_1.birth_id).to eq(expected_birth_counter)
 
-    #   #     # Cain
-    #   #     expected_birth_counter += 1
-    #   #     child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
-    #   #     child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-    #   #     expect(child_1.birth_id).to eq(expected_birth_counter)
+          # Abel
+          expected_birth_counter += 1
+          child_2 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_2)
+          child_2.name = "Abel, child of #{child_2.name} and #{ancestor_eve.name}"
+          expect(child_2.birth_id).to eq(expected_birth_counter)
 
-    #   #     # Abel
-    #   #     expected_birth_counter += 1
-    #   #     child_2 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_2)
-    #   #     child_2.name = "Abel, child of #{child_2.name} and #{ancestor_eve.name}"
-    #   #     expect(child_2.birth_id).to eq(expected_birth_counter)
+          puts_debug
+          puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+          puts_debug
+          puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+          puts_debug
+          puts_debug "child_1: #{child_1.to_json}"
+          puts_debug
+          puts_debug "child_2: #{child_2.to_json}"
+        end
+      end
 
-    #   #     puts_debug
-    #   #     puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-    #   #     puts_debug
-    #   #     puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-    #   #     puts_debug
-    #   #     puts_debug "child_1: #{child_1.to_json}"
-    #   #     puts_debug
-    #   #     puts_debug "child_2: #{child_2.to_json}"
-    #   #   end
-    #   # end
+      describe "#mix_parts" do
+        context "first Adam then Eve followed by Cain" do
+          let(child_1) { my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1) }
 
-    #   describe "#mix_parts" do
-    #     context "first Adam then Eve followed by Cain" do
-    #       let(child_1) { my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1) }
+          let(learning_rate_expected_1) {
+            parent_a_part = ancestor_adam.learning_rate
+            parent_b_part = ancestor_eve.learning_rate
 
-    #       let(learning_rate_expected_1) {
-    #         parent_a_part = ancestor_adam.learning_rate
-    #         parent_b_part = ancestor_eve.learning_rate
+            vector_a_to_b = parent_b_part - parent_a_part
+            parent_a_part + (delta_child_1 * vector_a_to_b)
+          }
 
-    #         vector_a_to_b = parent_b_part - parent_a_part
-    #         parent_a_part + (delta_child_1 * vector_a_to_b)
-    #       }
+          let(momentum_expected_1) {
+            parent_a_part = ancestor_adam.momentum
+            parent_b_part = ancestor_eve.momentum
 
-    #       let(momentum_expected_1) {
-    #         parent_a_part = ancestor_adam.momentum
-    #         parent_b_part = ancestor_eve.momentum
+            vector_a_to_b = parent_b_part - parent_a_part
+            parent_a_part + (delta_child_1 * vector_a_to_b)
+          }
 
-    #         vector_a_to_b = parent_b_part - parent_a_part
-    #         parent_a_part + (delta_child_1 * vector_a_to_b)
-    #       }
+          before_each do
+            # Force variable to be initialized in specific order
 
-    #       before_each do
-    #         # Force variable to be initialized in specific order
+            # Adam
+            ancestor_adam.name = ancestor_adam.name + ""
 
-    #         # Adam
-    #         ancestor_adam.name = ancestor_adam.name + ""
+            # Eve
+            ancestor_eve.name = ancestor_eve.name + ""
 
-    #         # Eve
-    #         ancestor_eve.name = ancestor_eve.name + ""
+            # Cain
+            child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+          end
 
-    #         # Cain
-    #         child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-    #       end
+          it "debug" do
+            puts_debug
+            puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+            puts_debug
+            puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+            puts_debug
+            puts_debug "child_1: #{child_1.to_json}"
+            puts_debug
 
-    #       it "debug" do
-    #         puts_debug
-    #         puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-    #         puts_debug
-    #         puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-    #         puts_debug
-    #         puts_debug "child_1: #{child_1.to_json}"
-    #         puts_debug
+            # puts_debug
+            # puts_debug "ancestor_adam: #{ancestor_adam.to_pretty_json}"
+            # puts_debug
+            # puts_debug "ancestor_eve: #{ancestor_eve.to_pretty_json}"
+            # puts_debug
+            # puts_debug "child_1: #{child_1.to_pretty_json}"
+            # puts_debug
+          end
 
-    #         # puts_debug
-    #         # puts_debug "ancestor_adam: #{ancestor_adam.to_pretty_json}"
-    #         # puts_debug
-    #         # puts_debug "ancestor_eve: #{ancestor_eve.to_pretty_json}"
-    #         # puts_debug
-    #         # puts_debug "child_1: #{child_1.to_pretty_json}"
-    #         # puts_debug
-    #       end
+          context "first child" do
+            context "gets expected value(s) for" do
 
-    #       context "first child" do
-    #         context "gets expected value(s) for" do
-    #           it "learning_rate" do
-    #             expect(child_1.learning_rate).to eq(learning_rate_expected_1)
-    #           end
+              it "learning_rate" do
+                expect(child_1.learning_rate).to eq(learning_rate_expected_1)
+              end
 
-    #           it "momentum" do
-    #             expect(child_1.momentum).to eq(momentum_expected_1)
-    #           end
+              it "momentum" do
+                expect(child_1.momentum).to eq(momentum_expected_1)
+              end
 
-    #           # ... do likewise for other applicable variables
-    #         end
+              # ... do likewise for other applicable variables
 
-    #         context "does not get exact copy of either parent for values of" do
-    #           it "learning_rate" do
-    #             expect(child_1.learning_rate).not_to eq(ancestor_adam)
-    #             expect(child_1.learning_rate).not_to eq(ancestor_eve)
-    #           end
+              context "mini_net_set" do
+                let(li) { 0 }
+                let(ti) { li }
 
-    #           it "momentum" do
-    #             expect(child_1.momentum).not_to eq(ancestor_adam)
-    #             expect(child_1.momentum).not_to eq(ancestor_eve)
-    #           end
+                let(ancestor_adam_mini_net) { ancestor_adam.mini_net_set[li][ti] }
+                let(ancestor_eve_mini_net) { ancestor_eve.mini_net_set[li][ti] }
+                let(child_1_mini_net) { child_1.mini_net_set[li][ti] }
+                
+                context "gets expected value(s) for" do
+                  it "learning_rate" do
+                    expect(ancestor_adam.learning_rate).to eq(ancestor_adam_mini_net.learning_rate)
+                    expect(ancestor_eve.learning_rate).to eq(ancestor_eve_mini_net.learning_rate)
+                    expect(child_1.learning_rate).to eq(child_1_mini_net.learning_rate)
 
-    #           # ... do likewise for other applicable variables
-    #         end
-    #       end
-    #     end
-    #   end
+                    expect(child_1_mini_net.learning_rate).to eq(learning_rate_expected_1)
+                  end
+
+                  it "momentum" do
+                    # expect(child_1.momentum).to eq(momentum_expected_1)
+
+                    expect(ancestor_adam.momentum).to eq(ancestor_adam_mini_net.momentum)
+                    expect(ancestor_eve.momentum).to eq(ancestor_eve_mini_net.momentum)
+                    expect(child_1.momentum).to eq(child_1_mini_net.momentum)
+
+                    expect(child_1_mini_net.momentum).to eq(momentum_expected_1)
+
+                  end
+
+                  # ... do likewise for other applicable variables
+
+                end
+              end
+            end
+
+            context "does not get exact copy of either parent for values of" do
+              it "learning_rate" do
+                expect(child_1.learning_rate).not_to eq(ancestor_adam)
+                expect(child_1.learning_rate).not_to eq(ancestor_eve)
+              end
+
+              it "momentum" do
+                expect(child_1.momentum).not_to eq(ancestor_adam)
+                expect(child_1.momentum).not_to eq(ancestor_eve)
+              end
+
+              # ... do likewise for other applicable variables
+
+              context "mini_net_set" do
+                let(li) { 0 }
+                let(ti) { li }
+
+                let(ancestor_adam_mini_net) { ancestor_adam.mini_net_set[li][ti] }
+                let(ancestor_eve_mini_net) { ancestor_eve.mini_net_set[li][ti] }
+                let(child_1_mini_net) { child_1.mini_net_set[li][ti] }
+                
+                context "does not get exact copy of either parent for values of" do
+                  it "learning_rate" do
+                    expect(child_1_mini_net.learning_rate).not_to eq(ancestor_adam_mini_net)
+                    expect(child_1_mini_net.learning_rate).not_to eq(ancestor_eve_mini_net)
+                  end
+    
+                  it "momentum" do
+                    expect(child_1_mini_net.momentum).not_to eq(ancestor_adam_mini_net)
+                    expect(child_1_mini_net.momentum).not_to eq(ancestor_eve_mini_net)
+                  end
+    
+                  # ... do likewise for other applicable variables
+    
+                end
+              end
+            end
+          end
+        end
+      end
   end
 end
-
-# let(weights_expected_1) {
-#   ancestor_adam.weights.map_with_index do |sa, i|
-#     parent_a_part = sa
-#     parent_b_part = ancestor_eve.weights[i]
-
-#     vector_a_to_b = parent_b_part - parent_a_part
-#     parent_a_part + (delta_child_1 * vector_a_to_b)
-#   end
-# }
-# let(weights_expected_2) {
-#   ancestor_adam.weights.map_with_index do |sa, i|
-#     parent_a_part = sa
-#     parent_b_part = ancestor_eve.weights[i]
-
-#     vector_a_to_b = parent_b_part - parent_a_part
-#     parent_a_part + (delta_child_2 * vector_a_to_b)
-#   end
-# }
-
-# let(momentum_expected_1) {
-#   ancestor_adam.momentum.map_with_index do |sa, i|
-#     parent_a_part = sa
-#     parent_b_part = ancestor_eve.momentum[i]
-
-#     vector_a_to_b = parent_b_part - parent_a_part
-#     parent_a_part + (delta_child_1 * vector_a_to_b)
-#   end
-# }
-# let(momentum_expected_2) {
-#   ancestor_adam.momentum.map_with_index do |sa, i|
-#     parent_a_part = sa
-#     parent_b_part = ancestor_eve.momentum[i]
-
-#     vector_a_to_b = parent_b_part - parent_a_part
-#     parent_a_part + (delta_child_2 * vector_a_to_b)
-#   end
-# }
-
-# let(config_cain) {
-#   config_default_randomized.merge(
-#     name: "Cain", learning_rate: ancestor_adam_learning_rate_expected
-#   )
-# }
-
-# let(config_abel) {
-#   config_default_randomized.merge(
-#     name: "Abel", learning_rate: ancestor_adam_learning_rate_expected
-#   )
-# }
-
-# expect(ancestor_adam.learning_rate).to eq(ancestor_adam_learning_rate_expected)
-
-# expected_birth_counter += 1
-# expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
-# expect(ancestor_eve.learning_rate).to eq(ancestor_eve_learning_rate_expected)
-
-# # cain
-# child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
-# child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-
-# puts_debug "child_1: #{child_1.to_json}"
-# expected_birth_counter += 1
-# expect(child_1.birth_id).to eq(expected_birth_counter)
-# expect(child_1.learning_rate).to eq(delta_child_1)
-
-# # expect(child_1.weights).to eq(weights_expected_1)
-# # expect(child_1.momentum).to eq(momentum_expected_1)
-
-# # abel
-# child_2 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_2)
-# child_2.name = "Abel, child of #{child_2.name} and #{ancestor_eve.name}"
-
-# puts_debug "child_2: #{child_2.to_json}"
-# expected_birth_counter += 1
-# expect(child_2.birth_id).to eq(expected_birth_counter)
-# expect(child_2.learning_rate).to eq(delta_child_2)
-
-# # expect(child_2.weights).to eq(weights_expected_2)
-# # expect(child_2.momentum).to eq(momentum_expected_2)
-
-# puts_debug
-# puts_debug "Now, in order or youngest to oldest:"
-# [ancestor_adam, ancestor_eve, child_1, child_2].sort_by do |person|
-#   (- person.birth_id)
-# end.each do |person|
-#   puts_debug "person: #{person.to_json}"
-# end

--- a/spec/ai4cr/neural_network/rnn/rnn_simple_manager_spec.cr
+++ b/spec/ai4cr/neural_network/rnn/rnn_simple_manager_spec.cr
@@ -8,7 +8,7 @@ end
 Spectator.describe Ai4cr::NeuralNetwork::Rnn::RnnSimpleManager do
   let(my_breed_manager) { Ai4cr::NeuralNetwork::Rnn::RnnSimpleManager.new }
 
-  # describe "For Adam and Eve examples" do
+  describe "For Adam and Eve examples" do
   #   let(delta_child_1) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
   #   let(delta_child_2) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
 
@@ -212,7 +212,7 @@ Spectator.describe Ai4cr::NeuralNetwork::Rnn::RnnSimpleManager do
   #       end
   #     end
   #   end
-  # end
+  end
 end
 
 # let(weights_expected_1) {

--- a/spec/ai4cr/neural_network/rnn/rnn_simple_manager_spec.cr
+++ b/spec/ai4cr/neural_network/rnn/rnn_simple_manager_spec.cr
@@ -9,270 +9,266 @@ Spectator.describe Ai4cr::NeuralNetwork::Rnn::RnnSimpleManager do
   let(my_breed_manager) { Ai4cr::NeuralNetwork::Rnn::RnnSimpleManager.new }
 
   describe "For Adam and Eve examples" do
-      let(delta_child_1) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
-      let(delta_child_2) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
+    let(delta_child_1) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
+    let(delta_child_2) { Ai4cr::Data::Utils.rand_neg_half_to_pos_one_and_half_no_zero_no_one }
 
-      let(ancestor_adam_learning_rate_expected) { 0.1 }
-      let(ancestor_eve_learning_rate_expected) { 0.9 }
+    let(ancestor_adam_learning_rate_expected) { 0.1 }
+    let(ancestor_eve_learning_rate_expected) { 0.9 }
 
-      let(config_default_randomized) {
-        Ai4cr::NeuralNetwork::Rnn::RnnSimple.new.config
-      }
+    let(config_default_randomized) {
+      Ai4cr::NeuralNetwork::Rnn::RnnSimple.new.config
+    }
 
-      let(config_adam) {
-        config_default_randomized.merge(
-          name: "Adam", learning_rate: ancestor_adam_learning_rate_expected,
-          momentum: Ai4cr::Data::Utils.rand_excluding,
-          deriv_scale: Ai4cr::Data::Utils.rand_excluding / 2.0
-        )
-      }
+    let(config_adam) {
+      config_default_randomized.merge(
+        name: "Adam", learning_rate: ancestor_adam_learning_rate_expected,
+        momentum: Ai4cr::Data::Utils.rand_excluding,
+        deriv_scale: Ai4cr::Data::Utils.rand_excluding / 2.0
+      )
+    }
 
-      let(config_eve) {
-        config_default_randomized.merge(
-          name: "Eve", learning_rate: ancestor_eve_learning_rate_expected,
-          momentum: Ai4cr::Data::Utils.rand_excluding,
-          deriv_scale: Ai4cr::Data::Utils.rand_excluding / 2.0
-        )
-      }
+    let(config_eve) {
+      config_default_randomized.merge(
+        name: "Eve", learning_rate: ancestor_eve_learning_rate_expected,
+        momentum: Ai4cr::Data::Utils.rand_excluding,
+        deriv_scale: Ai4cr::Data::Utils.rand_excluding / 2.0
+      )
+    }
 
-      let(ancestor_adam) { my_breed_manager.create(**config_adam) }
-      let(ancestor_eve) { my_breed_manager.create(**config_eve) }
+    let(ancestor_adam) { my_breed_manager.create(**config_adam) }
+    let(ancestor_eve) { my_breed_manager.create(**config_eve) }
 
-      before_each do
-        my_breed_manager.counter_reset
+    before_each do
+      my_breed_manager.counter_reset
+    end
+
+    it "learning rates of Adam and Eve are different" do
+      expect(ancestor_adam.learning_rate).to eq(ancestor_adam_learning_rate_expected)
+      expect(ancestor_eve.learning_rate).to eq(ancestor_eve_learning_rate_expected)
+      expect(ancestor_adam.learning_rate).not_to eq(ancestor_eve.learning_rate)
+    end
+
+    context "birth_id's are in the consistent order (when birthed in order" do
+      it "first Adam" do
+        expected_birth_counter = 0
+
+        # Adam
+        expected_birth_counter += 1
+        expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+
+        puts_debug
+        puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
       end
-      
-      it "learning rates of Adam and Eve are different" do
-        expect(ancestor_adam.learning_rate).to eq(ancestor_adam_learning_rate_expected)
-        expect(ancestor_eve.learning_rate).to eq(ancestor_eve_learning_rate_expected)
-        expect(ancestor_adam.learning_rate).not_to eq(ancestor_eve.learning_rate)
+
+      it "first Adam then Eve" do
+        expected_birth_counter = 0
+
+        # Adam
+        expected_birth_counter += 1
+        expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+
+        # Eve
+        expected_birth_counter += 1
+        expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+
+        puts_debug
+        puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+        puts_debug
+        puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
       end
 
-      context "birth_id's are in the consistent order (when birthed in order" do
-        it "first Adam" do
-          expected_birth_counter = 0
+      it "first Adam then Eve followed by Cain" do
+        expected_birth_counter = 0
+
+        # Adam
+        expected_birth_counter += 1
+        expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+
+        # Eve
+        expected_birth_counter += 1
+        expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+
+        # Cain
+        expected_birth_counter += 1
+        child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
+        child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+        expect(child_1.birth_id).to eq(expected_birth_counter)
+
+        puts_debug
+        puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+        puts_debug
+        puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+        puts_debug
+        puts_debug "child_1: #{child_1.to_json}"
+      end
+
+      it "first Adam then Eve followed by Cain and then Abel" do
+        expected_birth_counter = 0
+
+        # Adam
+        expected_birth_counter += 1
+        expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+
+        # Eve
+        expected_birth_counter += 1
+        expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+
+        # Cain
+        expected_birth_counter += 1
+        child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
+        child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
+        expect(child_1.birth_id).to eq(expected_birth_counter)
+
+        # Abel
+        expected_birth_counter += 1
+        child_2 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_2)
+        child_2.name = "Abel, child of #{child_2.name} and #{ancestor_eve.name}"
+        expect(child_2.birth_id).to eq(expected_birth_counter)
+
+        puts_debug
+        puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
+        puts_debug
+        puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
+        puts_debug
+        puts_debug "child_1: #{child_1.to_json}"
+        puts_debug
+        puts_debug "child_2: #{child_2.to_json}"
+      end
+    end
+
+    describe "#mix_parts" do
+      context "first Adam then Eve followed by Cain" do
+        let(child_1) { my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1) }
+
+        let(learning_rate_expected_1) {
+          parent_a_part = ancestor_adam.learning_rate
+          parent_b_part = ancestor_eve.learning_rate
+
+          vector_a_to_b = parent_b_part - parent_a_part
+          parent_a_part + (delta_child_1 * vector_a_to_b)
+        }
+
+        let(momentum_expected_1) {
+          parent_a_part = ancestor_adam.momentum
+          parent_b_part = ancestor_eve.momentum
+
+          vector_a_to_b = parent_b_part - parent_a_part
+          parent_a_part + (delta_child_1 * vector_a_to_b)
+        }
+
+        before_each do
+          # Force variable to be initialized in specific order
 
           # Adam
-          expected_birth_counter += 1
-          expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
-
-          puts_debug
-          puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-        end
-
-        it "first Adam then Eve" do
-          expected_birth_counter = 0
-
-          # Adam
-          expected_birth_counter += 1
-          expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
+          ancestor_adam.name = ancestor_adam.name + ""
 
           # Eve
-          expected_birth_counter += 1
-          expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
-
-          puts_debug
-          puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-          puts_debug
-          puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-        end
-
-        it "first Adam then Eve followed by Cain" do
-          expected_birth_counter = 0
-
-          # Adam
-          expected_birth_counter += 1
-          expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
-
-          # Eve
-          expected_birth_counter += 1
-          expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
+          ancestor_eve.name = ancestor_eve.name + ""
 
           # Cain
-          expected_birth_counter += 1
-          child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
           child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-          expect(child_1.birth_id).to eq(expected_birth_counter)
+        end
 
+        it "debug" do
           puts_debug
           puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
           puts_debug
           puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
           puts_debug
           puts_debug "child_1: #{child_1.to_json}"
+          puts_debug
+
+          # puts_debug
+          # puts_debug "ancestor_adam: #{ancestor_adam.to_pretty_json}"
+          # puts_debug
+          # puts_debug "ancestor_eve: #{ancestor_eve.to_pretty_json}"
+          # puts_debug
+          # puts_debug "child_1: #{child_1.to_pretty_json}"
+          # puts_debug
         end
 
-        it "first Adam then Eve followed by Cain and then Abel" do
-          expected_birth_counter = 0
-
-          # Adam
-          expected_birth_counter += 1
-          expect(ancestor_adam.birth_id).to eq(expected_birth_counter)
-
-          # Eve
-          expected_birth_counter += 1
-          expect(ancestor_eve.birth_id).to eq(expected_birth_counter)
-
-          # Cain
-          expected_birth_counter += 1
-          child_1 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1)
-          child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-          expect(child_1.birth_id).to eq(expected_birth_counter)
-
-          # Abel
-          expected_birth_counter += 1
-          child_2 = my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_2)
-          child_2.name = "Abel, child of #{child_2.name} and #{ancestor_eve.name}"
-          expect(child_2.birth_id).to eq(expected_birth_counter)
-
-          puts_debug
-          puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-          puts_debug
-          puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-          puts_debug
-          puts_debug "child_1: #{child_1.to_json}"
-          puts_debug
-          puts_debug "child_2: #{child_2.to_json}"
-        end
-      end
-
-      describe "#mix_parts" do
-        context "first Adam then Eve followed by Cain" do
-          let(child_1) { my_breed_manager.breed(ancestor_adam, ancestor_eve, delta: delta_child_1) }
-
-          let(learning_rate_expected_1) {
-            parent_a_part = ancestor_adam.learning_rate
-            parent_b_part = ancestor_eve.learning_rate
-
-            vector_a_to_b = parent_b_part - parent_a_part
-            parent_a_part + (delta_child_1 * vector_a_to_b)
-          }
-
-          let(momentum_expected_1) {
-            parent_a_part = ancestor_adam.momentum
-            parent_b_part = ancestor_eve.momentum
-
-            vector_a_to_b = parent_b_part - parent_a_part
-            parent_a_part + (delta_child_1 * vector_a_to_b)
-          }
-
-          before_each do
-            # Force variable to be initialized in specific order
-
-            # Adam
-            ancestor_adam.name = ancestor_adam.name + ""
-
-            # Eve
-            ancestor_eve.name = ancestor_eve.name + ""
-
-            # Cain
-            child_1.name = "Cain, child of #{child_1.name} and #{ancestor_eve.name}"
-          end
-
-          it "debug" do
-            puts_debug
-            puts_debug "ancestor_adam: #{ancestor_adam.to_json}"
-            puts_debug
-            puts_debug "ancestor_eve: #{ancestor_eve.to_json}"
-            puts_debug
-            puts_debug "child_1: #{child_1.to_json}"
-            puts_debug
-
-            # puts_debug
-            # puts_debug "ancestor_adam: #{ancestor_adam.to_pretty_json}"
-            # puts_debug
-            # puts_debug "ancestor_eve: #{ancestor_eve.to_pretty_json}"
-            # puts_debug
-            # puts_debug "child_1: #{child_1.to_pretty_json}"
-            # puts_debug
-          end
-
-          context "first child" do
-            context "gets expected value(s) for" do
-
-              it "learning_rate" do
-                expect(child_1.learning_rate).to eq(learning_rate_expected_1)
-              end
-
-              it "momentum" do
-                expect(child_1.momentum).to eq(momentum_expected_1)
-              end
-
-              # ... do likewise for other applicable variables
-
-              context "mini_net_set" do
-                let(li) { 0 }
-                let(ti) { li }
-
-                let(ancestor_adam_mini_net) { ancestor_adam.mini_net_set[li][ti] }
-                let(ancestor_eve_mini_net) { ancestor_eve.mini_net_set[li][ti] }
-                let(child_1_mini_net) { child_1.mini_net_set[li][ti] }
-                
-                context "gets expected value(s) for" do
-                  it "learning_rate" do
-                    expect(ancestor_adam.learning_rate).to eq(ancestor_adam_mini_net.learning_rate)
-                    expect(ancestor_eve.learning_rate).to eq(ancestor_eve_mini_net.learning_rate)
-                    expect(child_1.learning_rate).to eq(child_1_mini_net.learning_rate)
-
-                    expect(child_1_mini_net.learning_rate).to eq(learning_rate_expected_1)
-                  end
-
-                  it "momentum" do
-                    # expect(child_1.momentum).to eq(momentum_expected_1)
-
-                    expect(ancestor_adam.momentum).to eq(ancestor_adam_mini_net.momentum)
-                    expect(ancestor_eve.momentum).to eq(ancestor_eve_mini_net.momentum)
-                    expect(child_1.momentum).to eq(child_1_mini_net.momentum)
-
-                    expect(child_1_mini_net.momentum).to eq(momentum_expected_1)
-
-                  end
-
-                  # ... do likewise for other applicable variables
-
-                end
-              end
+        context "first child" do
+          context "gets expected value(s) for" do
+            it "learning_rate" do
+              expect(child_1.learning_rate).to eq(learning_rate_expected_1)
             end
 
-            context "does not get exact copy of either parent for values of" do
-              it "learning_rate" do
-                expect(child_1.learning_rate).not_to eq(ancestor_adam)
-                expect(child_1.learning_rate).not_to eq(ancestor_eve)
-              end
+            it "momentum" do
+              expect(child_1.momentum).to eq(momentum_expected_1)
+            end
 
-              it "momentum" do
-                expect(child_1.momentum).not_to eq(ancestor_adam)
-                expect(child_1.momentum).not_to eq(ancestor_eve)
-              end
+            # ... do likewise for other applicable variables
 
-              # ... do likewise for other applicable variables
+            context "mini_net_set" do
+              let(li) { 0 }
+              let(ti) { li }
 
-              context "mini_net_set" do
-                let(li) { 0 }
-                let(ti) { li }
+              let(ancestor_adam_mini_net) { ancestor_adam.mini_net_set[li][ti] }
+              let(ancestor_eve_mini_net) { ancestor_eve.mini_net_set[li][ti] }
+              let(child_1_mini_net) { child_1.mini_net_set[li][ti] }
 
-                let(ancestor_adam_mini_net) { ancestor_adam.mini_net_set[li][ti] }
-                let(ancestor_eve_mini_net) { ancestor_eve.mini_net_set[li][ti] }
-                let(child_1_mini_net) { child_1.mini_net_set[li][ti] }
-                
-                context "does not get exact copy of either parent for values of" do
-                  it "learning_rate" do
-                    expect(child_1_mini_net.learning_rate).not_to eq(ancestor_adam_mini_net)
-                    expect(child_1_mini_net.learning_rate).not_to eq(ancestor_eve_mini_net)
-                  end
-    
-                  it "momentum" do
-                    expect(child_1_mini_net.momentum).not_to eq(ancestor_adam_mini_net)
-                    expect(child_1_mini_net.momentum).not_to eq(ancestor_eve_mini_net)
-                  end
-    
-                  # ... do likewise for other applicable variables
-    
+              context "gets expected value(s) for" do
+                it "learning_rate" do
+                  expect(ancestor_adam.learning_rate).to eq(ancestor_adam_mini_net.learning_rate)
+                  expect(ancestor_eve.learning_rate).to eq(ancestor_eve_mini_net.learning_rate)
+                  expect(child_1.learning_rate).to eq(child_1_mini_net.learning_rate)
+
+                  expect(child_1_mini_net.learning_rate).to eq(learning_rate_expected_1)
                 end
+
+                it "momentum" do
+                  # expect(child_1.momentum).to eq(momentum_expected_1)
+
+                  expect(ancestor_adam.momentum).to eq(ancestor_adam_mini_net.momentum)
+                  expect(ancestor_eve.momentum).to eq(ancestor_eve_mini_net.momentum)
+                  expect(child_1.momentum).to eq(child_1_mini_net.momentum)
+
+                  expect(child_1_mini_net.momentum).to eq(momentum_expected_1)
+                end
+
+                # ... do likewise for other applicable variables
+              end
+            end
+          end
+
+          context "does not get exact copy of either parent for values of" do
+            it "learning_rate" do
+              expect(child_1.learning_rate).not_to eq(ancestor_adam)
+              expect(child_1.learning_rate).not_to eq(ancestor_eve)
+            end
+
+            it "momentum" do
+              expect(child_1.momentum).not_to eq(ancestor_adam)
+              expect(child_1.momentum).not_to eq(ancestor_eve)
+            end
+
+            # ... do likewise for other applicable variables
+
+            context "mini_net_set" do
+              let(li) { 0 }
+              let(ti) { li }
+
+              let(ancestor_adam_mini_net) { ancestor_adam.mini_net_set[li][ti] }
+              let(ancestor_eve_mini_net) { ancestor_eve.mini_net_set[li][ti] }
+              let(child_1_mini_net) { child_1.mini_net_set[li][ti] }
+
+              context "does not get exact copy of either parent for values of" do
+                it "learning_rate" do
+                  expect(child_1_mini_net.learning_rate).not_to eq(ancestor_adam_mini_net)
+                  expect(child_1_mini_net.learning_rate).not_to eq(ancestor_eve_mini_net)
+                end
+
+                it "momentum" do
+                  expect(child_1_mini_net.momentum).not_to eq(ancestor_adam_mini_net)
+                  expect(child_1_mini_net.momentum).not_to eq(ancestor_eve_mini_net)
+                end
+
+                # ... do likewise for other applicable variables
               end
             end
           end
         end
       end
+    end
   end
 end

--- a/src/ai4cr/breed/manager.cr
+++ b/src/ai4cr/breed/manager.cr
@@ -95,9 +95,7 @@ module Ai4cr
         end
         birth_id = channel.receive
 
-        child = parts_to_copy(parent_a, parent_b, delta)
-
-        child = mix_parts(child, parent_a, parent_b, delta)
+        child = copy_and_mix(parent_a, parent_b, delta)
 
         child.birth_id = birth_id
         child.parent_a_id = parent_a.birth_id
@@ -105,6 +103,11 @@ module Ai4cr
         child.breed_delta = delta
 
         child
+      end
+
+      def copy_and_mix(parent_a, parent_b, delta)
+        child = parts_to_copy(parent_a, parent_b, delta)
+        mix_parts(child, parent_a, parent_b, delta)
       end
 
       def parts_to_copy(parent_a : T, parent_b : T, delta)

--- a/src/ai4cr/breed/manager.cr
+++ b/src/ai4cr/breed/manager.cr
@@ -85,18 +85,26 @@ module Ai4cr
         vector_a_to_b == 0.0 ? 0.0 : -error_a / vector_a_to_b
       end
 
-      def breed(parent_a : T, parent_b : T, delta = Ai4cr::Data::Utils.rand_excluding(scale: 2, offset: -0.5), **params)
+      def breed(parent_a : T, parent_b : T, delta = Ai4cr::Data::Utils.rand_excluding(scale: 2, offset: -0.5)) #, **params)
         raise "Must be a Breed Client!" unless T < Breed::Client
 
         # i.e.: VIA parents
+        birth_id = breed_counter_tick
+
+        child = copy_and_mix(parent_a, parent_b, delta)
+
+        breed_id_and_delta(child, birth_id, parent_a, parent_b, delta)
+      end
+
+      def breed_counter_tick
         channel = Channel(Int32).new
         spawn do
           channel.send(@counter.inc(T.name))
         end
-        birth_id = channel.receive
+        channel.receive
+      end
 
-        child = copy_and_mix(parent_a, parent_b, delta)
-
+      def breed_id_and_delta(child, birth_id, parent_a, parent_b, delta)
         child.birth_id = birth_id
         child.parent_a_id = parent_a.birth_id
         child.parent_b_id = parent_b.birth_id
@@ -134,7 +142,7 @@ module Ai4cr
         child
       end
 
-      def mix_one_part_number(parent_a_part : Float64, parent_b_part : Float64, delta)
+      def mix_one_part_number(parent_a_part : Number, parent_b_part : Number, delta)
         vector_a_to_b = parent_b_part - parent_a_part
         parent_a_part + (delta * vector_a_to_b)
       end

--- a/src/ai4cr/breed/manager.cr
+++ b/src/ai4cr/breed/manager.cr
@@ -85,7 +85,7 @@ module Ai4cr
         vector_a_to_b == 0.0 ? 0.0 : -error_a / vector_a_to_b
       end
 
-      def breed(parent_a : T, parent_b : T, delta = Ai4cr::Data::Utils.rand_excluding(scale: 2, offset: -0.5)) #, **params)
+      def breed(parent_a : T, parent_b : T, delta = Ai4cr::Data::Utils.rand_excluding(scale: 2, offset: -0.5)) # , **params)
         raise "Must be a Breed Client!" unless T < Breed::Client
 
         # i.e.: VIA parents

--- a/src/ai4cr/data/utils.cr
+++ b/src/ai4cr/data/utils.cr
@@ -1,9 +1,9 @@
 module Ai4cr
   module Data
     class Utils
-      SCALE_DEFAULT = 1.0
-      OFFSET_DEFAULT = 0.0
-      EXCLUDES_DEFAULT = [0.0, 1.0]
+      SCALE_DEFAULT     = 1.0
+      OFFSET_DEFAULT    = 0.0
+      EXCLUDES_DEFAULT  = [0.0, 1.0]
       PROXIMITY_DEFAULT = 0.0001
 
       # Ai4cr::Data::Utils.rand_excluding (with defaults), aka: def self.rand_zero_to_one_no_zero

--- a/src/ai4cr/neural_network/cmn/mini_net_concerns/props_and_inits.cr
+++ b/src/ai4cr/neural_network/cmn/mini_net_concerns/props_and_inits.cr
@@ -11,12 +11,12 @@ module Ai4cr
 
               deriv_scale: @deriv_scale,
 
-              disable_bias: disable_bias,
+              disable_bias: @disable_bias,
               bias_default: @bias_default,
 
-              learning_rate: learning_rate,
-              momentum:      momentum,
-              history_size:  history_size,
+              learning_rate: @learning_rate,
+              momentum:      @momentum,
+              history_size:  @history_size,
 
               name: name,
             }

--- a/src/ai4cr/neural_network/rnn/rnn_simple.cr
+++ b/src/ai4cr/neural_network/rnn/rnn_simple.cr
@@ -17,6 +17,7 @@ module Ai4cr
         include RnnSimpleConcerns::TrainAndAdjust
         include RnnSimpleConcerns::RollUps
         include RnnSimpleConcerns::DataUtils
+        include Ai4cr::Breed::Client
       end
     end
   end

--- a/src/ai4cr/neural_network/rnn/rnn_simple_concerns/props_and_inits.cr
+++ b/src/ai4cr/neural_network/rnn/rnn_simple_concerns/props_and_inits.cr
@@ -34,6 +34,10 @@ module Ai4cr
               learning_rate: @learning_rate,
               momentum:      @momentum,
               deriv_scale:   @deriv_scale,
+
+              history_size: @history_size,
+
+              name: name
             }
           end
 
@@ -55,8 +59,12 @@ module Ai4cr
             momentum : Float64? = nil,
             deriv_scale : Float64? = nil,
 
-            history_size : Int32? = 10
+            history_size : Int32? = 10,
+
+            name : String? = nil
           )
+            @name = name.nil? ? "" : name
+
             init_network(hidden_size_given, disable_bias, learning_rate, momentum, deriv_scale, history_size)
             @error_stats = Ai4cr::ErrorStats.new(history_size)
           end

--- a/src/ai4cr/neural_network/rnn/rnn_simple_concerns/props_and_inits.cr
+++ b/src/ai4cr/neural_network/rnn/rnn_simple_concerns/props_and_inits.cr
@@ -37,7 +37,7 @@ module Ai4cr
 
               history_size: @history_size,
 
-              name: name
+              name: name,
             }
           end
 

--- a/src/ai4cr/neural_network/rnn/rnn_simple_concerns/train_and_adjust.cr
+++ b/src/ai4cr/neural_network/rnn/rnn_simple_concerns/train_and_adjust.cr
@@ -10,6 +10,7 @@ module Ai4cr
 
           # getter history_size : Int32 = 10 # Instead, refer to error_stats.history_size
           getter error_stats : Ai4cr::ErrorStats
+          getter history_size = 0
 
           # def eval_and_compare(input_set_given, output_set_expected, until_min_avg_error = UNTIL_MIN_AVG_ERROR_DEFAULT)
           #   eval(input_set_given)

--- a/src/ai4cr/neural_network/rnn/rnn_simple_manager.cr
+++ b/src/ai4cr/neural_network/rnn/rnn_simple_manager.cr
@@ -2,19 +2,30 @@ module Ai4cr
   module NeuralNetwork
     module Rnn
       class RnnSimpleManager < Breed::Manager(RnnSimple)
-        def copy_and_mix(parent_a, parent_b, delta)
-          # TODO (probably ok)
-          child = parts_to_copy(parent_a, parent_b, delta)
-          mix_parts(child, parent_a, parent_b, delta)
-        end
-
-        def parts_to_copy(parent_a : RnnSimple, parent_b : RnnSimple, delta)
-          # TODO (probably ok)
-          T.from_json(parent_a.to_json)
-        end
+        getter mini_net_manager = Cmn::MiniNetManager.new
 
         def mix_parts(child : RnnSimple, parent_a : RnnSimple, parent_b : RnnSimple, delta)
-          # TODO (probably: for each li and for each ti, breed associated MiniNet)
+          bias_default = mix_one_part_number(parent_a.bias_default, parent_b.bias_default, delta)
+          child.bias_default = bias_default
+
+          learning_rate = mix_one_part_number(parent_a.learning_rate, parent_b.learning_rate, delta)
+          child.learning_rate = learning_rate
+
+          momentum = mix_one_part_number(parent_a.momentum, parent_b.momentum, delta)
+          child.momentum = momentum
+
+          deriv_scale = mix_one_part_number(parent_a.deriv_scale, parent_b.deriv_scale, delta)
+          child.deriv_scale = deriv_scale
+
+          child.synaptic_layer_indexes.each do |li|
+            child.time_col_indexes.each do |ti|
+              mini_net_a = parent_a.mini_net_set[li][ti]
+              mini_net_b = parent_b.mini_net_set[li][ti]
+              
+              child.mini_net_set[li][ti] = mini_net_manager.breed(mini_net_a, mini_net_b, delta)              
+            end
+          end
+
           child
         end
       end

--- a/src/ai4cr/neural_network/rnn/rnn_simple_manager.cr
+++ b/src/ai4cr/neural_network/rnn/rnn_simple_manager.cr
@@ -21,8 +21,8 @@ module Ai4cr
             child.time_col_indexes.each do |ti|
               mini_net_a = parent_a.mini_net_set[li][ti]
               mini_net_b = parent_b.mini_net_set[li][ti]
-              
-              child.mini_net_set[li][ti] = mini_net_manager.breed(mini_net_a, mini_net_b, delta)              
+
+              child.mini_net_set[li][ti] = mini_net_manager.breed(mini_net_a, mini_net_b, delta)
             end
           end
 

--- a/src/ai4cr/neural_network/rnn/rnn_simple_manager.cr
+++ b/src/ai4cr/neural_network/rnn/rnn_simple_manager.cr
@@ -1,0 +1,24 @@
+module Ai4cr
+  module NeuralNetwork
+    module Rnn
+      class RnnSimpleManager < Breed::Manager(RnnSimple)
+
+        def copy_and_mix(parent_a, parent_b, delta)
+          # TODO (probably ok)
+          child = parts_to_copy(parent_a, parent_b, delta)
+          mix_parts(child, parent_a, parent_b, delta)
+        end
+
+        def parts_to_copy(parent_a : RnnSimple, parent_b : RnnSimple, delta)
+          # TODO (probably ok)
+          T.from_json(parent_a.to_json)
+        end
+        
+        def mix_parts(child : RnnSimple, parent_a : RnnSimple, parent_b : RnnSimple, delta)
+          # TODO (probably: for each li and for each ti, breed associated MiniNet)
+          child
+        end
+      end
+    end
+  end
+end

--- a/src/ai4cr/neural_network/rnn/rnn_simple_manager.cr
+++ b/src/ai4cr/neural_network/rnn/rnn_simple_manager.cr
@@ -2,7 +2,6 @@ module Ai4cr
   module NeuralNetwork
     module Rnn
       class RnnSimpleManager < Breed::Manager(RnnSimple)
-
         def copy_and_mix(parent_a, parent_b, delta)
           # TODO (probably ok)
           child = parts_to_copy(parent_a, parent_b, delta)
@@ -13,7 +12,7 @@ module Ai4cr
           # TODO (probably ok)
           T.from_json(parent_a.to_json)
         end
-        
+
         def mix_parts(child : RnnSimple, parent_a : RnnSimple, parent_b : RnnSimple, delta)
           # TODO (probably: for each li and for each ti, breed associated MiniNet)
           child


### PR DESCRIPTION
This is a partial fix for https://github.com/drhuffman12/ai4cr/issues/48 ; un-finished parts will be in future PR(s)!

  - [ ] Add net mixers
    - [ ] Breeder class(es) (renamed to `*Manager` classes)
      - [ ] `ChainBreeder < Breeder(Chain)`
      - [x] `RnnSimpleBreeder < Breeder(RnnSimple)`
      - [ ] (?) `BackproagationBreeder < Breeder(Backproagation)`
    - [ ] (?) `TeamUtils`
      - [ ] Should mix misc combo's of nets
      - [ ] Should use delta based on some mix of both parent's error scores
  - [ ] Refactor/re-write `Chain` (?); e.g.:
  - [ ] Fix `spec_bench` (re `Chain`?); e.g.:
    ```
    --------
      plot: ''
      error_stats.history: '[]'
    ```
  - [ ] CI should test builds for:
    - [x] Linux
    - [ ] Mac
    - [ ] Windows
  - [ ] Code cleanup!
  - [ ] Update version!!!